### PR TITLE
Fix assertion failure

### DIFF
--- a/zmtp-dissector.lua
+++ b/zmtp-dissector.lua
@@ -473,7 +473,7 @@ function zmtp_proto.dissector(tvb, pinfo, tree)
         pinfo.cols.info = table.concat(desc, "; ")
         --pinfo.tap_data = tap
 
-        return offset
+        return
 end
 
 -- register zmq to handle tcp ports 5550-5560


### PR DESCRIPTION
A certain capture was giving this warning:

    epan/dissectors/packet-tcp.c:4162: failed assertion
    "save_desegment_offset == pinfo->desegment_offset &&
    save_desegment_len == pinfo->desegment_len

New-style dissectors (such as the LUA one) may return a number. Its
meaning:

 - negative: need more bytes (not implemented yet, treated as positive).
 - positive: data is accepted (in the future it should mean "consumed
   this number of bytes").
 - zero: reject data, a different dissector should handle it.

When zero, the dissector should *not* set desegment_offset and
desegment_length since the data was rejected already. Just return no
number, then all data will be considered part of this protocol. This is
also documented at https://wiki.wireshark.org/Lua/Dissectors.