### PR TITLE
Wireshark uses new config dir for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Installation
 
 This dissector requires Lua 5.2 or newer.
 
-    mkdir -p ~/.wireshark/plugins
-    git clone git://github.com/whitequark/zmtp-wireshark ~/.wireshark/plugins/zmtp-wireshark
+    mkdir -p ~/.config/wireshark/plugins
+    git clone git://github.com/whitequark/zmtp-wireshark ~/.config/wireshark/plugins/zmtp-wireshark
 
 Usage
 -----


### PR DESCRIPTION
see https://www.wireshark.org/docs/relnotes/wireshark-2.0.0.html