### PR TITLE
Allow subdissectors to register for a specific TCP port

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+Copyright (c) 2019 Viveris Technologies <adiren.destugues@opensource.viveris.fr>
 Copyright (c) 2014 Peter Zotov <whitequark@whitequark.org>
 Copyright (c) 2011 by Robert G. Jakabosky <bobby@neoawareness.com>
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This dissector requires Lua 5.2 or newer.
 Usage
 -----
 
-As ZeroMQ ports are inherently application-specific, you first need to set up the port
-range in Preferences → Protocols → ZMTP.
+As ZeroMQ ports are inherently application-specific, you need to use "Decode As -> ZMTP" on your
+zeromq packets. Alternatively, subdissectors can register the ZMTP dissector on specific TCP ports
+to automate decoding.
 
 You can use expression `zmtp` to filter packets. TCP segments are automatically reassembled.
 
@@ -38,11 +39,12 @@ Subdissectors
 -------------
 
 This dissector supports calling subdissectors for an application-level protocol. As ZMTP does
-not have a generic way of specifying the inner protocol, it is necessary to specify the protocol
-in the preferences.
+not have a generic way of specifying the inner protocol, the mapping is done using TCP ports.
 
 A subdissector that wishes to observe ZMTP frames must register itself in the `zmtp.protocol`
-dissector table.
+dissector table, using the TCP port as a key. Both source and dest ports are checked, so
+bidirectional links (request/response, for example) will need a dissector that can decode both
+directions.
 
 License
 -------


### PR DESCRIPTION
Replace the name-based table for subdissectors with a table based on the
TCP port. This allows using multiple subdissectors in the same capture.

Leave the responsibility of registering TCP ports to subdissectors
(unfortunately it does not seem possible to list the ports of our
dissector table and push them into the tcp.port table). Alternatively,
"Decode as" can be used to decode ZMTP on a specific port.

As a result, no preferences and configuration are needed anymore. Update
the README accordingly.

Signed-off-by: Adrien Destugues <adrien.destugues@opensource.viveris.fr>