### PR TITLE
Move add_for_decode_as() out of zmtp_proto.init

### DIFF
--- a/zmtp-dissector.lua
+++ b/zmtp-dissector.lua
@@ -552,7 +552,5 @@ function zmtp_proto.dissector(tvb, pinfo, tree)
         return
 end
 
--- Register ZMTP for "decode as"
-function zmtp_proto.init(arg1, arg2)
-    DissectorTable.get("tcp.port"):add_for_decode_as(zmtp_proto)
-end
+-- Register ZMTP for "decode as
+DissectorTable.get("tcp.port"):add_for_decode_as(zmtp_proto)


### PR DESCRIPTION
I'm writing a subdissector and I noticed that every time I run Analyze->Reload Lua Plugins (Ctrl+Shift+L), I would lose the saved "Decode As..." configuration I set to enable ZMTP dissection. I assumed the plugin wasn't being reloaded correctly and noticed that the WireShark examples don't use an init function. I tried removing it and the issue is gone. I'm not sure exactly what the implications are, but I'll leave this PR for your review.